### PR TITLE
feat: replace ts-morph with lsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherry-pick-import",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Cherry-pick imported specified identifiers from a module",
   "author": "Tmk <i@tmk.im>",
   "keywords": [
@@ -33,13 +33,15 @@
     "test": "vitest"
   },
   "dependencies": {
-    "jiti": "^1.21.6",
-    "ts-morph": "^23.0.0"
+    "jiti": "^1.21.6"
   },
   "devDependencies": {
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
     "vitest": "^2.0.2"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
   },
   "packageManager": "pnpm@9.5.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       jiti:
         specifier: ^1.21.6
         version: 1.21.6
-      ts-morph:
-        specifier: ^23.0.0
-        version: 23.0.0
     devDependencies:
       tsup:
         specifier: ^8.1.0
@@ -287,9 +284,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ts-morph/common@0.24.0':
-    resolution: {integrity: sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==}
-
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
@@ -380,9 +374,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  code-block-writer@13.0.1:
-    resolution: {integrity: sha512-c5or4P6erEA69TxaxTNcHUNcIn+oyxSRTOWV+pSYF+z4epXqNvwvJ70XPGjPNgue83oAFAPBRQYwpAJ/Hpe/Sg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -588,11 +579,6 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -630,9 +616,6 @@ packages:
 
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
-
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -811,9 +794,6 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  ts-morph@23.0.0:
-    resolution: {integrity: sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==}
 
   tsup@8.1.0:
     resolution: {integrity: sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==}
@@ -1094,13 +1074,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
-  '@ts-morph/common@0.24.0':
-    dependencies:
-      fast-glob: 3.3.2
-      minimatch: 9.0.5
-      mkdirp: 3.0.1
-      path-browserify: 1.0.1
-
   '@types/estree@1.0.5': {}
 
   '@types/node@20.14.9':
@@ -1202,8 +1175,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  code-block-writer@13.0.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1414,8 +1385,6 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mkdirp@3.0.1: {}
-
   ms@2.1.2: {}
 
   mz@2.7.0:
@@ -1447,8 +1416,6 @@ snapshots:
       mimic-fn: 4.0.0
 
   package-json-from-dist@1.0.0: {}
-
-  path-browserify@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -1607,11 +1574,6 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
-
-  ts-morph@23.0.0:
-    dependencies:
-      '@ts-morph/common': 0.24.0
-      code-block-writer: 13.0.1
 
   tsup@8.1.0(postcss@8.4.39)(typescript@5.5.3):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import createJITI from 'jiti';
 import babelTransform from 'jiti/dist/babel.js';
-import { Project, ts } from 'ts-morph';
+import { cherryPickTransform } from './transform';
 
 export interface CherryPickImportOptions {
   filename: string;
@@ -15,44 +15,8 @@ export function cherryPickImport({ filename, identifiers }: CherryPickImportOpti
     requireCache: false,
     extensions: ['.ts', '.js', '.mts', '.mjs', '.tsx'],
     transform(opts) {
-      if (opts.filename === filename)
-        return {
-          code: cherryPick(filename, opts.source, identifiers),
-        };
+      if (opts.filename === filename) opts.source = cherryPickTransform({ filename, code: opts.source, identifiers });
       return babelTransform(opts);
     },
   })(filename);
-}
-
-function cherryPick(filename: string, code: string, identifiers: string[]) {
-  const basename = path.basename(filename);
-  const project = new Project({
-    compilerOptions: {
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ESNext,
-    },
-    useInMemoryFileSystem: true,
-    skipAddingFilesFromTsConfig: true,
-    skipFileDependencyResolution: true,
-    skipLoadingLibFiles: true,
-  });
-
-  const sourceFile = project.createSourceFile(basename, code);
-  sourceFile.transform((traversal) => {
-    const node = traversal.visitChildren();
-    if (ts.isImportDeclaration(node)) {
-      // remove all import declarations that have no specifiers, assuming that they have no side effects.
-      if (!node.importClause) return traversal.factory.createEmptyStatement();
-    }
-    return node;
-  });
-  const variableDeclarations = sourceFile.getVariableDeclarations();
-  variableDeclarations.filter((exp) => !identifiers.includes(exp.getName())).forEach((exp) => exp.remove());
-  sourceFile.removeDefaultExport().fixUnusedIdentifiers().saveSync();
-
-  project.emitSync();
-
-  const fs = project.getFileSystem();
-  const extIndex = basename.lastIndexOf(path.extname(basename));
-  return fs.readFileSync(basename.slice(0, extIndex) + '.js', 'utf8');
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,133 @@
+import ts from 'typescript/lib/tsserverlibrary';
+
+const compilerOptions: ts.CompilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ESNext,
+  skipDefaultLibCheck: true,
+  skipLibCheck: true,
+};
+
+export interface CherryPickTransformOptions {
+  filename: string;
+  code: string;
+  identifiers: string[];
+}
+
+function createLanguageServiceHost(sourceFilename: string, sourceText: string) {
+  let currentScriptVersion = 0;
+  let currentSourceText = sourceText;
+
+  const languageServiceHost: ts.LanguageServiceHost = {
+    jsDocParsingMode: ts.JSDocParsingMode.ParseNone,
+    getCompilationSettings() {
+      return compilerOptions;
+    },
+    getScriptFileNames() {
+      return [sourceFilename];
+    },
+    getScriptVersion(fileName) {
+      if (fileName !== sourceFilename) return '0';
+      return String(currentScriptVersion);
+    },
+    getScriptSnapshot(fileName) {
+      if (fileName !== sourceFilename) return undefined;
+      return ts.ScriptSnapshot.fromString(currentSourceText);
+    },
+    getCurrentDirectory() {
+      return '/';
+    },
+    directoryExists(directoryName) {
+      return directoryName === '/';
+    },
+    getDefaultLibFileName(options) {
+      return ts.getDefaultLibFileName(options);
+    },
+    readFile() {
+      return undefined;
+    },
+    fileExists(path: string): boolean {
+      return path === sourceFilename;
+    },
+  };
+
+  function updateFile(newSourceText: string) {
+    currentSourceText = newSourceText;
+    currentScriptVersion++;
+  }
+
+  return {
+    languageServiceHost,
+    updateFile,
+  };
+}
+
+export function cherryPickTransform(options: CherryPickTransformOptions): string {
+  const { filename: sourceFilename } = options;
+  const { languageServiceHost, updateFile } = createLanguageServiceHost(sourceFilename, trimExport(options));
+  const lsp = ts.createLanguageService(languageServiceHost);
+  updateFile(applyFix(lsp, sourceFilename, 'unusedIdentifier_delete'));
+  // updateFile(applyFix(lsp, sourceFilename, 'unusedIdentifier_deleteImports'));
+  return lsp.getEmitOutput(sourceFilename).outputFiles[0].text;
+}
+
+function applyFix(lsp: ts.LanguageService, fileName: string, fixId: string) {
+  const sourceFile = lsp.getProgram()!.getSourceFile(fileName)!;
+  let text = sourceFile.text;
+  const combinedCodeFix = lsp.getCombinedCodeFix({ type: 'file', fileName }, fixId, {}, {});
+  for (const change of combinedCodeFix.changes) {
+    for (const { span, newText } of change.textChanges) {
+      text = text.slice(0, span.start) + newText + text.slice(span.start + span.length);
+    }
+  }
+  return text;
+}
+
+export function trimExport({ filename, code, identifiers }: CherryPickTransformOptions): string {
+  return ts
+    .transpileModule(code, {
+      compilerOptions,
+      jsDocParsingMode: ts.JSDocParsingMode.ParseNone,
+      fileName: filename,
+      transformers: {
+        before: [
+          (ctx) => {
+            const visitor: ts.Visitor = (node) => {
+              if (ts.isImportDeclaration(node) && !node.importClause) return;
+              if (
+                ts.isVariableStatement(node) &&
+                // marked as export
+                node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+              ) {
+                // export const xxx = { ... };
+                const declarations = node.declarationList.declarations;
+                const [shouldKeep, shouldRemove] = partition(
+                  declarations,
+                  (decl) => ts.isIdentifier(decl.name) && identifiers.includes(decl.name.escapedText.toString())
+                );
+                if (shouldKeep.length === 0) return; // no declarations should be kept, just remove the node
+              }
+              if (ts.isExportAssignment(node)) {
+                // export default xxx;
+                const escapedName = (node as unknown as ts.Type).symbol.escapedName;
+                if (!identifiers.includes(escapedName.toString())) return;
+              }
+              return ts.visitEachChild(node, visitor, ctx);
+            };
+            return (sf) => ts.visitEachChild(sf, visitor, ctx);
+          },
+        ],
+      },
+    })
+    .outputText.replace(/^\s*\/\/\s*@ts-nocheck/g, '//');
+}
+
+function partition<T>(array: ArrayLike<T>, predicate: (value: T) => boolean): [T[], T[]] {
+  const truthy: T[] = [];
+  const falsy: T[] = [];
+  for (let i = 0; i < array.length; ++i) {
+    const item = array[i];
+    if (predicate(item)) truthy.push(item);
+    else falsy.push(item);
+  }
+  return [truthy, falsy];
+}

--- a/test.mts
+++ b/test.mts
@@ -1,9 +1,10 @@
-import ts from 'typescript/lib/tsserverlibrary';
+import { cherryPickTransform } from './src/transform';
 
 const sourceText = `
 import cssText from 'data-text:~/contents/plasmo-overlay.css';
 import unused from 'unused';
 import type { PlasmoCSConfig } from 'plasmo';
+import '@/global.less';
 
 export const config: PlasmoCSConfig = {
   matches: ['https://www.plasmo.com/*'],
@@ -29,9 +30,9 @@ function PlasmoOverlay() {
       CSUI OVERLAY FIXED POSITION
     </span>
   );
-};
+}
 
-// export default PlasmoOverlay;
+export default PlasmoOverlay;
 `;
 
 const start = performance.now();
@@ -39,83 +40,8 @@ const start = performance.now();
 const sourceFilename = '/mod.tsx';
 const keepIdentifiers = ['config'];
 
-const compilerOptions: ts.CompilerOptions = {
-  module: ts.ModuleKind.ESNext,
-  target: ts.ScriptTarget.ESNext,
-  skipDefaultLibCheck: true,
-  skipLibCheck: true,
-};
+const result = cherryPickTransform({ filename: sourceFilename, code: sourceText, identifiers: keepIdentifiers });
 
-function createLanguageServiceHost(sourceFilename: string, sourceText: string) {
-  let currentScriptVersion = 0;
-  let currentSourceText = sourceText;
-
-  const languageServiceHost: ts.LanguageServiceHost = {
-    jsDocParsingMode: ts.JSDocParsingMode.ParseNone,
-    getCompilationSettings() {
-      return compilerOptions;
-    },
-    getScriptFileNames() {
-      return [sourceFilename];
-    },
-    getScriptVersion(fileName) {
-      if (fileName !== sourceFilename) return '0';
-      return String(currentScriptVersion);
-    },
-    getScriptSnapshot(fileName) {
-      if (fileName !== sourceFilename) return undefined;
-      return ts.ScriptSnapshot.fromString(currentSourceText);
-    },
-    getCurrentDirectory() {
-      return '/';
-    },
-    directoryExists(directoryName) {
-      return directoryName === '/';
-    },
-    getDefaultLibFileName(options) {
-      return ts.getDefaultLibFileName(options);
-    },
-    readFile(path: string, encoding?: string): string | undefined {
-      throw new Error('readFile Function not implemented.');
-    },
-    fileExists(path: string): boolean {
-      return path === sourceFilename;
-    },
-  };
-
-  function updateFile(newSourceText: string) {
-    currentSourceText = newSourceText;
-    currentScriptVersion++;
-  }
-
-  return {
-    languageServiceHost,
-    updateFile,
-  };
-}
-
-const { languageServiceHost, updateFile } = createLanguageServiceHost(sourceFilename, sourceText);
-const lsp = ts.createLanguageService(languageServiceHost);
-
-// console.log(lsp.getSuggestionDiagnostics(sourceFilename).map((diagnostics) => diagnostics.messageText));
-
-const program = lsp.getProgram()!;
-
-function applyFix(program: ts.Program, fileName: string, fixId: string) {
-  const sf = program.getSourceFile(sourceFilename)!;
-  let text = sf.text;
-  const combinedCodeFix = lsp.getCombinedCodeFix({ type: 'file', fileName }, fixId, {}, {});
-  for (const change of combinedCodeFix.changes) {
-    for (const { span, newText } of change.textChanges) {
-      text = text.slice(0, span.start) + newText + text.slice(span.start + span.length);
-      updateFile(text);
-    }
-  }
-}
-
-applyFix(program, sourceFilename, 'unusedIdentifier_delete');
-// applyFix(program, sourceFilename, 'unusedIdentifier_deleteImports');
-
-console.log(lsp.getEmitOutput(sourceFilename).outputFiles[0].text);
+console.log(result);
 
 console.log('elapsed:', `${performance.now() - start}ms`);

--- a/test.mts
+++ b/test.mts
@@ -1,0 +1,130 @@
+import ts from 'typescript';
+
+const sourceText = `
+import cssText from 'data-text:~/contents/plasmo-overlay.css';
+import type { PlasmoCSConfig } from 'plasmo';
+
+export const config: PlasmoCSConfig = {
+  matches: ['https://www.plasmo.com/*'],
+  css: ['font.css'],
+};
+
+export const getStyle = () => {
+  const style = document.createElement('style');
+  style.textContent = cssText;
+  return style;
+};
+
+function PlasmoOverlay() {
+  return (
+    <span
+      className="hw-top"
+      style={{
+        padding: 12,
+      }}
+    >
+      CSUI OVERLAY FIXED POSITION
+    </span>
+  );
+};
+
+export default PlasmoOverlay;
+`;
+
+const start = performance.now();
+
+const sourceFilename = '/mod.tsx';
+const keepIdentifiers = ['config'];
+
+class LightCompilerHost implements ts.CompilerHost {
+  jsDocParsingMode = ts.JSDocParsingMode.ParseNone;
+  getSourceFile(
+    fileName: string,
+    languageVersionOrOptions: ts.ScriptTarget | ts.CreateSourceFileOptions
+  ): ts.SourceFile | undefined {
+    if (fileName !== sourceFilename) return undefined;
+    return ts.createSourceFile(fileName, sourceText, languageVersionOrOptions, true);
+  }
+  getSourceFileByPath?(
+    fileName: string,
+    path: ts.Path,
+    languageVersionOrOptions: ts.ScriptTarget | ts.CreateSourceFileOptions,
+    onError?: (message: string) => void,
+    shouldCreateNewSourceFile?: boolean
+  ): ts.SourceFile | undefined {
+    throw new Error('getSourceFileByPath Method not implemented.');
+  }
+  getDefaultLibFileName(_options: ts.CompilerOptions): string {
+    return '';
+  }
+  writeFile(fileName: string, text: string) {
+    console.log('writeFile', fileName, text);
+  }
+
+  getCurrentDirectory(): string {
+    return '/';
+  }
+  getCanonicalFileName(fileName: string): string {
+    return fileName;
+  }
+  useCaseSensitiveFileNames(): boolean {
+    return true;
+  }
+  getNewLine(): string {
+    throw new Error('getNewLine Method not implemented.');
+  }
+  fileExists(fileName: string): boolean {
+    console.log('fileExists', fileName);
+    return fileName === sourceFilename;
+  }
+  readFile(fileName: string): string | undefined {
+    console.log('readFile', { fileName });
+    if (fileName === sourceFilename) return sourceText;
+    return undefined;
+  }
+  directoryExists(directoryName: string): boolean {
+    return directoryName === '/';
+  }
+}
+
+const compilerHost = new LightCompilerHost();
+
+const program = ts.createProgram({
+  rootNames: [sourceFilename],
+  options: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ESNext,
+    skipDefaultLibCheck: true,
+    skipLibCheck: true,
+  },
+  host: compilerHost,
+});
+
+const modSf = program.getSourceFile(sourceFilename)!;
+const typeChecker = program.getTypeChecker();
+
+const modSymbol = typeChecker.getSymbolAtLocation(modSf)!;
+const exportsOfModule = typeChecker.getExportsOfModule(modSymbol);
+
+const unusedDecls: ts.Node[] = exportsOfModule
+  .filter((exp) => !keepIdentifiers.includes(exp.escapedName.toString()))
+  .flatMap((exp) => exp.declarations || []);
+
+const newSf = ts.transform(
+  modSf,
+  [
+    (ctx) => {
+      const visitor: ts.Visitor = (node) => {
+        if (unusedDecls.includes(node)) {
+          return;
+        }
+        return ts.visitEachChild(node, visitor, ctx);
+      };
+      return (sf) => ts.visitEachChild(sf, visitor, ctx);
+    },
+  ],
+  undefined
+);
+
+console.log(ts.createPrinter().printNode(ts.EmitHint.Unspecified, newSf.transformed[0], newSf.transformed[0]));
+console.log('elapsed:', `${performance.now() - start}ms`);

--- a/tests/transform.spec.ts
+++ b/tests/transform.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+import { cherryPickTransform, CherryPickTransformOptions, trimExport } from '../src/transform';
+
+describe('Plasmo', () => {
+  const code = `
+    import cssText from 'data-text:~/contents/plasmo-overlay.css';
+    import type { PlasmoCSConfig } from 'plasmo';
+
+    export const config: PlasmoCSConfig = {
+      matches: ['https://www.plasmo.com/*'],
+      css: ['font.css'],
+    };
+
+    export const getStyle = () => {
+      const style = document.createElement('style');
+      style.textContent = cssText;
+      return style;
+    };
+
+    const PlasmoOverlay = () => {
+      return (
+        <span
+          className="hw-top"
+          style={{
+            padding: 12,
+          }}
+        >
+          CSUI OVERLAY FIXED POSITION
+        </span>
+      );
+    };
+
+    export default PlasmoOverlay;
+  `;
+
+  const options: CherryPickTransformOptions = {
+    filename: '/contents.tsx',
+    code,
+    identifiers: ['config'],
+  };
+
+  test('trimExport', () => {
+    const result = trimExport(options);
+    expect(result).toMatchInlineSnapshot(`
+      "import cssText from 'data-text:~/contents/plasmo-overlay.css';
+      export const config = {
+          matches: ['https://www.plasmo.com/*'],
+          css: ['font.css'],
+      };
+      const PlasmoOverlay = () => {
+          return (<span className="hw-top" style={{
+                  padding: 12,
+              }}>
+                CSUI OVERLAY FIXED POSITION
+              </span>);
+      };
+      "
+    `);
+  });
+
+  test('cherryPickTransform', () => {
+    const result = cherryPickTransform(options);
+    expect(result).toMatchInlineSnapshot(`
+    "export const config = {
+        matches: ['https://www.plasmo.com/*'],
+        css: ['font.css'],
+    };
+    "
+  `);
+  });
+});


### PR DESCRIPTION
Reasons:

- `ts-morph` bundles ts, which makes it large
- only a few functionalities are used, with a low ROI